### PR TITLE
Update `README.md` and fix command line argument typos

### DIFF
--- a/IFdataGen/IFdataGen.cpp
+++ b/IFdataGen/IFdataGen.cpp
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <string>
 #include <vector>
-//#include <filesystem>
 #include <ctime>
 #ifdef _OPENMP
 #include <omp.h>
@@ -46,7 +45,6 @@ int QuantSamplesIQ4(complex_number Samples[], int Length, unsigned char QuantSam
 int QuantSamplesIQ8(complex_number Samples[], int Length, unsigned char QuantSamples[], double GainScale);
 void ShowHelp(const char* ProgramName);
 bool ParseCommandLineArgs(int argc, char* argv[], CommandArguments &Arguments);
-//std::string CreateOutputDirectory(const std::string& outputFilename);
 void CreateTagFile(const std::string& tagFilePath, const OUTPUT_PARAM& outputParam);
 
 CTrajectory Trajectory;
@@ -162,14 +160,9 @@ int main(int argc, char* argv[])
 	CurPos = LlaToEcef(StartPos);
 	SpeedLocalToEcef(StartPos, StartVel, CurPos);
 
-	// Create output directory structure
-//	std::string outputDir = CreateOutputDirectory(OutputParam.filename);
-//	std::string binFilePath = outputDir + "/" + std::filesystem::path(OutputParam.filename).filename().string();
-//	std::string tagFilePath = binFilePath + ".tag";
 
-//	CreateTagFile(tagFilePath, OutputParam);
 
-//	printf("[INFO]\tOpening output file: %s\n", binFilePath.c_str());
+	printf("[INFO]\tOpening output file: %s\n", OutputParam.filename);
 	if ((IfFile = fopen(OutputParam.filename, "wb")) == NULL)
 	{
 		printf("[ERROR]\tFailed to open output file: %s\n", OutputParam.filename);
@@ -645,7 +638,8 @@ int main(int argc, char* argv[])
 
 //		for (j = 0; j < OutputParam.SampleFreq; j ++)
 //			printf("%f %f\n", NoiseArray[j].real, NoiseArray[j].imag);
-		if ((exec_cycle % 10) == 0)
+		// Enhanced progress reporting with percentage, MB/s, and ETA
+		if ((exec_cycle % 25) == 0)
 		{
 			auto current_time = std::chrono::high_resolution_clock::now();
 			auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - start_time).count();
@@ -988,8 +982,6 @@ int QuantSamplesIQ8(complex_number Samples[], int Length, unsigned char QuantSam
 void ShowHelp(const char* ProgramPath)
 {
 	// Extract just the executable name from the path
-//	std::string ProgramName = std::filesystem::path(programPath).filename().string();
-	// simplified programe name extract for compiler earlier than C++17 that does not support std::filesystem
 	std::string PathName = ProgramPath;
 	std::string ProgramName;
     size_t pos = PathName.find_last_of("/\\");
@@ -1001,18 +993,19 @@ void ShowHelp(const char* ProgramPath)
 	std::cout << "IFDataGen - GNSS IF Data Generator\n\n";
 	std::cout << "Usage: " << ProgramName << " [options]\n\n";
 	std::cout << "Available options:\n";
-	std::cout << "  --config, -c <FILE>     Configuration file (JSON) [REQUIRED]\n";
-	std::cout << "  --output, -o <FILE>     Output IF data file (overrides config)\n";
-	std::cout << "  --validate-only, -vo    Validate configuration and exit\n";
-	std::cout << "  --multi-thread, -mt     Force use multi-thread\n";
-	std::cout << "  --single-thread, -st    Force use single-thread\n";
-	std::cout << "  --tag, -t               Output tag file (output file name with .tag appended)\n";
-	std::cout << "  --help, -h              Show this help message\n\n";
+	std::cout << "   -c, 	--config <FILE>    Configuration file (JSON) [REQUIRED]\n";
+	std::cout << "   -o, 	--output <FILE>    Output IF data file (overrides config)\n";
+	std::cout << "   -vo, 	--validate-only    Validate configuration and exit\n";
+	std::cout << "   -mt, 	--multi-thread     Force use multi-thread\n";
+	std::cout << "   -st, 	--single-thread    Force use single-thread\n";
+	std::cout << "   -t,  	--tag              Output tag file (output file name with .tag appended)\n";
+	std::cout << "   -v, 	--version          Show version information\n";
+	std::cout << "   -h, 	--help             Show this help message\n\n";
 	std::cout << "Examples:\n";
-	std::cout << "  " << ProgramName << " -c config.json\n";
-	std::cout << "  " << ProgramName << " --config config.json --output mydata.bin\n";
-	std::cout << "  " << ProgramName << " -c config.json -o output.bin -s\n";
-	std::cout << "  " << ProgramName << " --config config.json -vo\n\n";
+	std::cout << "   " << ProgramName << " -c config.json\n";
+	std::cout << "   " << ProgramName << " --config config.json --output mydata.bin\n";
+	std::cout << "   " << ProgramName << " -c config.json -o output.bin -st\n";
+	std::cout << "   " << ProgramName << " --config config.json -vo\n\n";
 }
 
 bool ParseCommandLineArgs(int argc, char* argv[], CommandArguments &Arguments)
@@ -1021,7 +1014,7 @@ bool ParseCommandLineArgs(int argc, char* argv[], CommandArguments &Arguments)
 		"--help", "-h",	// 0
 		"--config", "-c",	// 1
 		"--output", "-o",	// 2
-		"--validateo-nly", "-vo",	// 3
+		"--validate-only", "-vo",	// 3
 		"--multi-thread", "-mt",	// 4
 		"--single-thread", "-st",	// 5
 		"--tag", "-t",	// 6

--- a/IFdataGen/README.md
+++ b/IFdataGen/README.md
@@ -235,29 +235,26 @@ IFDataGen - GNSS IF Data Generator
 Usage: IFdataGen [options]
 
 Available options:
-  --config, -c <FILE>     Configuration file (JSON) [REQUIRED]
-  --output, -o <FILE>     Output IF data file (overrides config)
-  --validate-only, -vo    Validate configuration and exit
-  --parallel, -p          Use parallel execution (default)
-  --serial, -s            Force serial execution
-  --help, -h              Show this help message
+  -c,   --config <FILE>    Configuration file (JSON) [REQUIRED]
+  -o,   --output <FILE>    Output IF data file (overrides config)
+  -vo,  --validate-only    Validate configuration and exit
+  -mt,  --multi-thread     Force use multi-thread
+  -st,  --single-thread    Force use single-thread
+  -t,   --tag              Output tag file (output file name with .tag appended)
+  -v,   --version          Show version information
+  -h,   --help             Show this help message
 
 Examples:
   IFdataGen -c config.json
-  IFdataGen --config config.json --output mydata.bin
-  IFdataGen -c config.json -o output.bin -s
+  IFdataGen --config config.json --output mydata.bin -t
+  IFdataGen -c config.json -o output.bin -st
   IFdataGen --config config.json -vo
-
-Output structure:
-  filename/
-        |-- filename.bin     (IF data)
-        |-- filename.bin.tag (metadata)
 ```
 
 * Now lets pass the cofiguration json file to the generator. From the `IFdataGen` directory run:
 
   ```cmd
-  ~/SignalSim/IFdataGen$ ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json # Linux
+  ~/SignalSim/IFdataGen$ ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json -t # Linux
   ```
 
 * On successful execution, you'll see output similar to:
@@ -271,12 +268,10 @@ Output structure:
 [INFO]  JSON file read successfully: configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json
 [INFO]  Loading ephemeris file: ../EphData/BRDC00IGS_R_20211700000_01D_MN.rnx
 [INFO]  Ephemeris file loaded successfully: ../EphData/BRDC00IGS_R_20211700000_01D_MN.rnx
-[INFO]  Creating output directory: bin_signals/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1
-[INFO]  Output directory created successfully: bin_signals/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1
-[INFO]  Creating tag file: bin_signals/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin.tag
-[INFO]  Tag file created: bin_signals/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin.tag
-[INFO]  Opening output file: bin_signals/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin
+[INFO]  Opening output file: GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin
 [INFO]  Output file opened successfully.
+[INFO]  Creating tag file: GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin.tag
+[INFO]  Tag file created: GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.bin.tag
 [INFO]  OpenMP configured for PARALLEL execution (20 threads auto-detected)
 [INFO]  Generating IF data with following satellite signals:
 
@@ -287,7 +282,7 @@ Output structure:
 
 Signals Summary Table:
 +---------------+-------------+--------------+------------------------------+
-| Constellation | Visible SVs | Signals / SV | Total Signals / Visible SVs |
+| Constellation | Visible SVs | Signals / SV | Total Signals / Visible SVs  |
 +---------------+-------------+--------------+------------------------------+
 | GPS           | 9           | 2            | 18                           |
 | BeiDou        | 10          | 2            | 20                           |
@@ -361,49 +356,49 @@ Galileo E1 with IF +7134kHz:
 
 ```
 
-* A `.bin` and `.bin.tag` files will be generated in `IFdataGen/bin_signals/fine_name/` directory. In above examlpe, the bin signal will land in `bin_signal/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1` directory. The `file_name` is the name which you set in `.json` file, the `.bin.tag` contains metadata (compatible with PocketSDR) about the signal generated.
+* A `.bin` and `.bin.tag` files will be generated in `IFdataGen/` directory (or next to the executable). In above examlpe, the bin signal will land in `IFdataGen/` directory. The `.bin.tag` contains metadata (information about the signal generated) (compatible with PocketSDR) about the signal generated.
 
   ---
 
 ### Bonus: Generate Other multi-Constellation IF Data
 
-Run the `IFdataGen.exe` with pre-computed examples `.json` files, present in `<path-to-repo>/SignalSim/IFdataGen/configs/` directory, to generate multi-constellation IF signals. Go inside `IFdataGen` directory and run the following commands:
+Run the `IFdataGen` with pre-computed examples `.json` files, present in `<path-to-repo>/SignalSim/IFdataGen/configs/` directory, to generate multi-constellation IF signals. Go inside `IFdataGen` directory and run the following commands:
 
 1. **GPS + BeiDou + Galileo (L1 Bands)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json -t # Windows (cmd/powersehh)
    ```
 2. **GPS + BeiDou + Galileo (L1 Bands with B1I)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L1CA_L1C_B1C_B1I_E1.json -t # Windows (cmd/powersehh)
    ```
 3. **GPS + BeiDou + Galileo + GLONASS (L1/G1 Bands)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_GLO_L1CA_L1C_B1C_B1I_E1_G1.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_GLO_L1CA_L1C_B1C_B1I_E1_G1.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_GLO_L1CA_L1C_B1C_B1I_E1_G1.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_GLO_L1CA_L1C_B1C_B1I_E1_G1.json -t # Windows (cmd/powersehh)
    ```
 4. **GPS + BeiDou + Galileo + GLONASS (L2/B2/G2 Bands)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_GLO_L2C_B2I_B2b_E5b_G2.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_GLO_L2C_B2I_B2b_E5b_G2.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_GLO_L2C_B2I_B2b_E5b_G2.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_GLO_L2C_B2I_B2b_E5b_G2.json -t # Windows (cmd/powersehh)
    ```
 5. **GPS + BeiDou + Galileo (L5/E5a/B2a Bands)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L5_B2a_E5a.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L5_B2a_E5a.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/GPS_BDS_GAL_L5_B2a_E5a.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\GPS_BDS_GAL_L5_B2a_E5a.json -t # Windows (cmd/powersehh)
    ```
 6. **BeiDou + Galileo (B3I/E6 Bands)**:
 
    ```cmd
-   ./out/build/release/IFdataGen -c configs/BDS_GAL_B3I_E6.json # Linux
-   .\out\build\x64-Release\IFdataGen -c configs\BDS_GAL_B3I_E6.json # Windows (cmd/powersehh)
+   ./out/build/release/IFdataGen -c configs/BDS_GAL_B3I_E6.json -t # Linux
+   .\out\build\x64-Release\IFdataGen -c configs\BDS_GAL_B3I_E6.json -t # Windows (cmd/powersehh)
    ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SignalSim is designed for both educational and professional use, with commercial
 
 ## Signal Support and Testing Status
 
-The following table shows the current testing status of various GNSS signals in SignalSim:
+The [Table](./IFdataGen/README.md#signal-support-and-testing-status) shows the current testing status of various GNSS signals.
 
 ## Key Components
 
@@ -63,8 +63,13 @@ The core libraries provide fundamental GNSS data processing capabilities includi
 
 ### 2025
 
+- **7/5/2025**
+  - Update/Fix the `README.md` of `IFdatagGen` directory
+  - Fix typos in command line arguments of help print function
+
 - **7/1/2025**
-  - Merge information display and command line arguments in PR#36
+  - Merge Fix, information display and command line arguments in PR#36
+  - Fix performance overheads in Nested Noise addition loop in `IFdataGen.cpp`
   - Add Build Instructions for Linux
   - Enhance signal generation status logs on terminal
   - Improve `CMakeLists.txt` configuration
@@ -98,7 +103,6 @@ The core libraries provide fundamental GNSS data processing capabilities includi
   - Explain how to set center frequency and bandwidth for each constellation in the [IFdataGen GNSS_Signal_Calculations](./IFdataGen/GNSS_Signal_Calculations.md).
   - Expand unit and integration tests for signal generation and update the test matrix accordingly.
   - Update  [IFdataGen README](./IFdataGen/README.md) with new examples and configuration guidance.
-
 
 - **5/14/2025**
   - Rewrite BCNAV1/2/3 navigation data stream generation method (ephemeris generation completed, almanac in next release)


### PR DESCRIPTION
- Update/Fix the `README.md` of `IFdatagGen` directory
- Fix typos in command line arguments of help print function